### PR TITLE
Add supply-chain hardened .npmrc (PER-8340)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,20 +4,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 12
-      - uses: actions/cache@v2
+          node-version: 20
+      - uses: actions/cache@v4
         with:
           path: ~/.npm
-          key: v1/${{ runner.os }}/node-12/${{ hashFiles('**/package-lock.lock') }}
-          restore-keys: v1/${{ runner.os }}/node-12/
+          key: v1/${{ runner.os }}/node-20/${{ hashFiles('**/package-lock.json') }}
+          restore-keys: v1/${{ runner.os }}/node-20/
       - name: Install dependencies
         run: npm install
       - name: Run tests
-        uses: percy/exec-action@v0.3.1
-        with:
-          custom-command: "npm test"
+        run: npm test
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,20 +4,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 12
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.npm
-          key: v1/${{ runner.os }}/node-12/${{ hashFiles('**/package-lock.lock') }}
+          key: v1/${{ runner.os }}/node-12/${{ hashFiles('**/package-lock.json') }}
           restore-keys: v1/${{ runner.os }}/node-12/
       - name: Install dependencies
         run: npm install
       - name: Run tests
-        uses: percy/exec-action@v0.3.1
-        with:
-          custom-command: "npm test"
+        run: npm test
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,18 +4,20 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
         with:
-          node-version: 20
-      - uses: actions/cache@v4
+          node-version: 12
+      - uses: actions/cache@v2
         with:
           path: ~/.npm
-          key: v1/${{ runner.os }}/node-20/${{ hashFiles('**/package-lock.json') }}
-          restore-keys: v1/${{ runner.os }}/node-20/
+          key: v1/${{ runner.os }}/node-12/${{ hashFiles('**/package-lock.lock') }}
+          restore-keys: v1/${{ runner.os }}/node-12/
       - name: Install dependencies
         run: npm install
       - name: Run tests
-        run: npm test
+        uses: percy/exec-action@v0.3.1
+        with:
+          custom-command: "npm test"
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,6 @@
+ignore-scripts=true
+strict-ssl=true
+save-exact=true
+audit-level=high
+engine-strict=true
+legacy-peer-deps=false

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,4 @@
-ignore-scripts=true
+ignore-scripts=false
 strict-ssl=true
 save-exact=true
 audit-level=high

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,4 @@
-ignore-scripts=false
+ignore-scripts=true
 strict-ssl=true
 save-exact=true
 audit-level=high


### PR DESCRIPTION
## Supply-chain hardening: add `.npmrc`

Flagged by the weekly supply-chain `.npmrc` audit ([PER-8340](https://browserstack.atlassian.net/browse/PER-8340), parent [SC-12282](https://browserstack.atlassian.net/browse/SC-12282)) with status `missing_file`.

Adds an `.npmrc` with the required hardening directives: `ignore-scripts`, `strict-ssl`, `save-exact`, `audit-level=high`, `engine-strict`, `legacy-peer-deps=false`. Public repo, so `access=restricted` is intentionally omitted (private-repo only).

> ⚠️ Reviewers: confirm CI `npm install` still passes — `ignore-scripts`/`engine-strict`/`legacy-peer-deps` can change install behavior.

Ref: [Supply Chain Security Enhancements Tech Spec](https://browserstack.atlassian.net/wiki/spaces/ENG/pages/6091571922/Supply+Chain+Security+Enhancements+Tech+Spec)

[PER-8340]: https://browserstack.atlassian.net/browse/PER-8340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SC-12282]: https://browserstack.atlassian.net/browse/SC-12282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ